### PR TITLE
Bump OpenMRS version to 2.8.7 and extend PowerMock profile

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          java: [ '8', '17' ]
+          java: [ '8', '11', '17' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>lime-emr</artifactId>
-		<version>1.1.1</version>
+		<version>1.1.2</version>
 	</parent>
 
 	<artifactId>lime-emr-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -13,7 +13,7 @@
 	<description>API project for LIME EMR dependencies and customizations</description>
 
 	<properties>
-		<openMRSVersion>2.6.6</openMRSVersion>
+		<openMRSVersion>2.8.7</openMRSVersion>
 		<idgenModuleVersion>4.11.0-SNAPSHOT</idgenModuleVersion>
 		<appointmentsModuleVersion>2.1.0-SNAPSHOT</appointmentsModuleVersion>
 	</properties>
@@ -119,7 +119,7 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>3.0.0-M5</version>
 						<configuration>
-							<argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED</argLine>
+							<argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED</argLine>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -15,7 +15,7 @@
 	<description>OMOD project for LIME EMR dependencies and customizations</description>
 
 	<properties>
-		<openMRSVersion>2.6.6</openMRSVersion>
+		<openMRSVersion>2.8.7</openMRSVersion>
 	</properties>
 
 	<dependencies>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>lime-emr</artifactId>
-		<version>1.1.1</version>
+		<version>1.1.2</version>
 	</parent>
 
 	<artifactId>lime-emr-omod</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<openMRSVersion>2.6.6</openMRSVersion>
+		<openMRSVersion>2.8.7</openMRSVersion>
 	</properties>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>lime-emr</artifactId>
-	<version>1.1.1</version>
+	<version>1.1.2</version>
 	<packaging>pom</packaging>
 	<name>MSF-OCG LIME EMR Module</name>
 


### PR DESCRIPTION
This pull request updates the project to use OpenMRS 2.8.7 and makes improvements to Java compatibility and test configuration. The most important changes are listed below.

**Dependency Updates:**

* Updated the `openMRSVersion` property to `2.8.7` in `pom.xml`, `api/pom.xml` and `omod/pom.xml` to ensure all modules use the latest OpenMRS version. 

**Build and Test Improvements:**

* Expanded the Java build matrix in `.github/workflows/build_and_publish.yml` to include Java 11, improving CI coverage across Java versions 8, 11, and 17.
* Added `--add-opens java.xml/jdk.xml.internal=ALL-UNNAMED` to the Maven Surefire plugin configuration in `api/pom.xml` to improve test compatibility with newer Java versions.